### PR TITLE
Refine logic for outlier filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "m2stitch"
-version = "0.5.2"
+version = "0.6.0"
 description = "M2Stitch"
 authors = ["Yohsuke Fukai <ysk@yfukai.net>"]
 license = "MIT"

--- a/src/m2stitch/_stage_model.py
+++ b/src/m2stitch/_stage_model.py
@@ -1,16 +1,16 @@
 import itertools
+from typing import Callable
 from typing import Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator
 
 from ._typing_utils import Float
 from ._typing_utils import Int
 
 
 def compute_image_overlap2(
-    grid: pd.DataFrame, direction: str, sizeY: Int, sizeX: Int, predictor: BaseEstimator
+    grid: pd.DataFrame, direction: str, sizeY: Int, sizeX: Int, predictor: Callable
 ) -> Tuple[Float, ...]:
     """Compute the value of the image overlap.
 
@@ -42,7 +42,7 @@ def compute_image_overlap2(
         ]
     )
     translation = translation[:, np.all(np.isfinite(translation), axis=0)]
-    c = predictor.fit_predict(translation.T)
+    c = predictor(translation.T)
     res = np.median(translation[:, c == 1], axis=1)
     assert len(res) == 2
     return tuple(res)

--- a/src/m2stitch/_typing_utils.py
+++ b/src/m2stitch/_typing_utils.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 NumArray = npt.NDArray[Any]
 FloatArray = npt.NDArray[np.float_]
 IntArray = npt.NDArray[np.int_]
+BoolArray = npt.NDArray[np.bool]
 
 Int = Union[int, np.int_]
 Float = Union[float, np.float_]

--- a/src/m2stitch/_typing_utils.py
+++ b/src/m2stitch/_typing_utils.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 NumArray = npt.NDArray[Any]
 FloatArray = npt.NDArray[np.float_]
 IntArray = npt.NDArray[np.int_]
-BoolArray = npt.NDArray[np.bool]
+BoolArray = npt.NDArray[np.bool_]
 
 Int = Union[int, np.int_]
 Float = Union[float, np.float_]


### PR DESCRIPTION
Now, the most probable image overlap is predicted using ElipticEnvelop. To avoid error from pixel discretization, we add small noise to the predicted displacements.